### PR TITLE
Add Admin Mode with teacher login and protected registration

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher login/logout (Admin Mode)
+- Register and unregister students (teacher-only actions)
 
 ## Getting Started
 
@@ -18,7 +19,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 2. Run the application:
 
    ```
-   python app.py
+   uvicorn app:app --reload
    ```
 
 3. Open your browser and go to:
@@ -30,7 +31,24 @@ A super simple FastAPI application that allows students to view and sign up for 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/login?username=<user>&password=<pass>`                    | Login as teacher and receive auth token                             |
+| POST   | `/auth/logout`                                                    | Logout current teacher token                                        |
+| GET    | `/auth/status`                                                    | Check if current token belongs to a logged-in teacher               |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student for an activity (teacher-only)                   |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Remove a student from an activity (teacher-only)                    |
+
+## Admin Mode Credentials
+
+Teacher usernames/passwords are stored in `teachers.json` and validated by the backend.
+
+Example file:
+
+```json
+{
+   "ms.smith": "teach123",
+   "mr.johnson": "teach456"
+}
+```
 
 ## Data Model
 

--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,12 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +20,15 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+if teachers_file.exists():
+    with teachers_file.open("r", encoding="utf-8") as file:
+        teacher_credentials = json.load(file)
+else:
+    teacher_credentials = {}
+
+active_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -88,9 +99,57 @@ def get_activities():
     return activities
 
 
+def _get_token(authorization: str | None) -> str | None:
+    if not authorization:
+        return None
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip()
+
+
+def _require_teacher_token(authorization: str | None) -> str:
+    token = _get_token(authorization)
+    if not token or token not in active_sessions:
+        raise HTTPException(
+            status_code=403,
+            detail="Teacher login required for this action"
+        )
+    return token
+
+
+@app.post("/auth/login")
+def login(username: str, password: str):
+    expected_password = teacher_credentials.get(username)
+    if not expected_password or expected_password != password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(24)
+    active_sessions[token] = username
+    return {"token": token, "username": username}
+
+
+@app.post("/auth/logout")
+def logout(authorization: str | None = Header(default=None)):
+    token = _get_token(authorization)
+    if token and token in active_sessions:
+        del active_sessions[token]
+    return {"message": "Logged out"}
+
+
+@app.get("/auth/status")
+def auth_status(authorization: str | None = Header(default=None)):
+    token = _get_token(authorization)
+    if token and token in active_sessions:
+        return {"is_teacher": True, "username": active_sessions[token]}
+    return {"is_teacher": False}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
     """Sign up a student for an activity"""
+    _require_teacher_token(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +170,10 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, authorization: str | None = Header(default=None)):
     """Unregister a student from an activity"""
+    _require_teacher_token(authorization)
+
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,97 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const userIconBtn = document.getElementById("user-icon-btn");
+  const authPanel = document.getElementById("auth-panel");
+  const showLoginBtn = document.getElementById("show-login-btn");
+  const loginForm = document.getElementById("login-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authLoggedOut = document.getElementById("auth-logged-out");
+  const authLoggedIn = document.getElementById("auth-logged-in");
+  const teacherName = document.getElementById("teacher-name");
+
+  const TOKEN_KEY = "teacherAuthToken";
+  let authToken = localStorage.getItem(TOKEN_KEY);
+  let isTeacherLoggedIn = false;
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function updateTeacherActionsUI() {
+    signupForm.querySelector("button[type='submit']").disabled = !isTeacherLoggedIn;
+    signupForm.querySelectorAll("input, select").forEach((field) => {
+      field.disabled = !isTeacherLoggedIn;
+    });
+
+    if (!isTeacherLoggedIn) {
+      signupForm.setAttribute("title", "Teacher login required");
+      document.querySelectorAll(".delete-btn").forEach((button) => {
+        button.disabled = true;
+        button.setAttribute("title", "Teacher login required");
+      });
+      return;
+    }
+
+    signupForm.removeAttribute("title");
+    document.querySelectorAll(".delete-btn").forEach((button) => {
+      button.disabled = false;
+      button.removeAttribute("title");
+    });
+  }
+
+  function showLoggedOutPanel() {
+    authLoggedOut.classList.remove("hidden");
+    authLoggedIn.classList.add("hidden");
+    loginForm.classList.add("hidden");
+  }
+
+  function showLoggedInPanel(username) {
+    teacherName.textContent = `Logged in as ${username}`;
+    authLoggedOut.classList.add("hidden");
+    loginForm.classList.add("hidden");
+    authLoggedIn.classList.remove("hidden");
+  }
+
+  async function refreshAuthState() {
+    if (!authToken) {
+      isTeacherLoggedIn = false;
+      showLoggedOutPanel();
+      updateTeacherActionsUI();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/status", {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      });
+      const status = await response.json();
+
+      if (status.is_teacher) {
+        isTeacherLoggedIn = true;
+        showLoggedInPanel(status.username);
+      } else {
+        isTeacherLoggedIn = false;
+        authToken = null;
+        localStorage.removeItem(TOKEN_KEY);
+        showLoggedOutPanel();
+      }
+    } catch (error) {
+      isTeacherLoggedIn = false;
+      showLoggedOutPanel();
+      console.error("Error checking auth status:", error);
+    }
+
+    updateTeacherActionsUI();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -60,6 +151,8 @@ document.addEventListener("DOMContentLoaded", () => {
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      updateTeacherActionsUI();
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -69,6 +162,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!isTeacherLoggedIn) {
+      showMessage("Only teachers can unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,32 +178,24 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +203,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!isTeacherLoggedIn) {
+      showMessage("Only teachers can register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +219,99 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  userIconBtn.addEventListener("click", () => {
+    authPanel.classList.toggle("hidden");
+  });
+
+  showLoginBtn.addEventListener("click", () => {
+    loginForm.classList.remove("hidden");
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch(
+        `/auth/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        {
+          method: "POST",
+        }
+      );
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed.", "error");
+        return;
+      }
+
+      authToken = result.token;
+      localStorage.setItem(TOKEN_KEY, authToken);
+      isTeacherLoggedIn = true;
+      showLoggedInPanel(result.username);
+      loginForm.reset();
+      updateTeacherActionsUI();
+      showMessage(`Welcome, ${result.username}.`, "success");
+    } catch (error) {
+      showMessage("Failed to login. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: authToken
+          ? {
+              Authorization: `Bearer ${authToken}`,
+            }
+          : {},
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    authToken = null;
+    localStorage.removeItem(TOKEN_KEY);
+    isTeacherLoggedIn = false;
+    showLoggedOutPanel();
+    updateTeacherActionsUI();
+    showMessage("Logged out.", "info");
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!authPanel.contains(event.target) && !userIconBtn.contains(event.target)) {
+      authPanel.classList.add("hidden");
+    }
+  });
+
   // Initialize app
+  refreshAuthState();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,29 @@
   </head>
   <body>
     <header>
+      <div class="auth-widget">
+        <button id="user-icon-btn" class="icon-btn" aria-label="User menu">👤</button>
+        <div id="auth-panel" class="auth-panel hidden">
+          <div id="auth-logged-out">
+            <button id="show-login-btn" type="button">Login</button>
+          </div>
+          <form id="login-form" class="hidden">
+            <div class="form-group">
+              <label for="username">Username:</label>
+              <input type="text" id="username" required />
+            </div>
+            <div class="form-group">
+              <label for="password">Password:</label>
+              <input type="password" id="password" required />
+            </div>
+            <button type="submit">Sign In</button>
+          </form>
+          <div id="auth-logged-in" class="hidden">
+            <p id="teacher-name"></p>
+            <button id="logout-btn" type="button">Logout</button>
+          </div>
+        </div>
+      </div>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,59 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+.auth-widget {
+  position: absolute;
+  right: 16px;
+  top: 16px;
+  text-align: left;
+}
+
+.icon-btn {
+  background-color: #fff;
+  color: #1a237e;
+  border: none;
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background-color: #f0f3ff;
+}
+
+.auth-panel {
+  position: absolute;
+  right: 0;
+  top: 46px;
+  width: 260px;
+  background-color: white;
+  color: #333;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  padding: 14px;
+  z-index: 50;
+}
+
+.auth-panel p {
+  margin-bottom: 10px;
+}
+
+.auth-panel .form-group {
+  margin-bottom: 10px;
+}
+
+.auth-panel .form-group input {
+  font-size: 14px;
+  padding: 8px;
 }
 
 main {
@@ -162,6 +211,11 @@ button {
 
 button:hover {
   background-color: #3949ab;
+}
+
+button:disabled {
+  background-color: #9fa8da;
+  cursor: not-allowed;
 }
 
 .message {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,4 @@
+{
+  "ms.smith": "teach123",
+  "mr.johnson": "teach456"
+}


### PR DESCRIPTION
## Summary
- add Admin Mode with teacher authentication backed by `src/teachers.json`
- add auth endpoints: `POST /auth/login`, `POST /auth/logout`, `GET /auth/status`
- restrict `signup` and `unregister` endpoints to logged-in teachers
- add top-right user icon/login panel in UI and disable register/unregister controls for students
- update API documentation in `src/README.md`

## Validation
- verified unauthorized signup returns `403`
- verified teacher login succeeds with sample credentials
- verified authorized signup returns `200` with a new email
- checked edited files for errors with diagnostics tool